### PR TITLE
Quit server onerror

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# Code Editors
+.vscode
+.idea

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "vsicons.presets.angular": false
-}

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ var net = require('net')
 var SERVER = (process.env.TRAVIS) ? 'gnatsd/gnatsd' : 'gnatsd'
 var DEFAULT_PORT = 4222
 
-function start_server (port, opt_flags, done) {
+function start_server(port, opt_flags, done) {
   if (!port) {
     port = DEFAULT_PORT
   }
@@ -22,6 +22,12 @@ function start_server (port, opt_flags, done) {
   }
 
   var server = spawn(SERVER, flags)
+
+  process.on('exit', () => {
+    if (server) {
+      server.kill()
+    }
+  })
 
   var start = new Date()
   var wait = 0
@@ -97,7 +103,7 @@ function start_server (port, opt_flags, done) {
 
 exports.start_server = start_server
 
-function stop_server (server) {
+function stop_server(server) {
   if (server !== undefined) {
     server.kill()
   }
@@ -108,7 +114,7 @@ exports.stop_server = stop_server
 // starts a number of servers in a cluster at the specified ports.
 // must call with at least one port.
 
-function start_cluster (ports, route_port, opt_flags, done) {
+function start_cluster(ports, route_port, opt_flags, done) {
   if (typeof opt_flags === 'function') {
     done = opt_flags
     opt_flags = null
@@ -139,7 +145,7 @@ function start_cluster (ports, route_port, opt_flags, done) {
 // adds more cluster members, if more than one server is added additional
 // servers are added after the specified delay.
 
-function add_member_with_delay (ports, route_port, delay, opt_flags, done) {
+function add_member_with_delay(ports, route_port, delay, opt_flags, done) {
   if (typeof opt_flags === 'function') {
     done = opt_flags
     opt_flags = null
@@ -160,7 +166,7 @@ function add_member_with_delay (ports, route_port, delay, opt_flags, done) {
 }
 exports.add_member_with_delay = add_member_with_delay
 
-function add_member (port, route_port, cluster_port, opt_flags, done) {
+function add_member(port, route_port, cluster_port, opt_flags, done) {
   if (typeof opt_flags === 'function') {
     done = opt_flags
     opt_flags = null

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ var net = require('net')
 var SERVER = (process.env.TRAVIS) ? 'gnatsd/gnatsd' : 'gnatsd'
 var DEFAULT_PORT = 4222
 
-function start_server(port, opt_flags, done) {
+function start_server (port, opt_flags, done) {
   if (!port) {
     port = DEFAULT_PORT
   }
@@ -103,7 +103,7 @@ function start_server(port, opt_flags, done) {
 
 exports.start_server = start_server
 
-function stop_server(server) {
+function stop_server (server) {
   if (server !== undefined) {
     server.kill()
   }
@@ -114,7 +114,7 @@ exports.stop_server = stop_server
 // starts a number of servers in a cluster at the specified ports.
 // must call with at least one port.
 
-function start_cluster(ports, route_port, opt_flags, done) {
+function start_cluster (ports, route_port, opt_flags, done) {
   if (typeof opt_flags === 'function') {
     done = opt_flags
     opt_flags = null
@@ -145,7 +145,7 @@ function start_cluster(ports, route_port, opt_flags, done) {
 // adds more cluster members, if more than one server is added additional
 // servers are added after the specified delay.
 
-function add_member_with_delay(ports, route_port, delay, opt_flags, done) {
+function add_member_with_delay (ports, route_port, delay, opt_flags, done) {
   if (typeof opt_flags === 'function') {
     done = opt_flags
     opt_flags = null
@@ -166,7 +166,7 @@ function add_member_with_delay(ports, route_port, delay, opt_flags, done) {
 }
 exports.add_member_with_delay = add_member_with_delay
 
-function add_member(port, route_port, cluster_port, opt_flags, done) {
+function add_member (port, route_port, cluster_port, opt_flags, done) {
   if (typeof opt_flags === 'function') {
     done = opt_flags
     opt_flags = null

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,11 +23,6 @@ function start_server (port, opt_flags, done) {
 
   var server = spawn(SERVER, flags)
 
-  process.on('exit', () => {
-    if (server) {
-      server.kill()
-    }
-  })
 
   var start = new Date()
   var wait = 0

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,6 @@ function start_server (port, opt_flags, done) {
 
   var server = spawn(SERVER, flags)
 
-
   var start = new Date()
   var wait = 0
   var maxWait = 5 * 1000 // 5 secs


### PR DESCRIPTION
# Update
Removed the process kill stuff. Now its only a cleanup

# Old Description
This PR ensures that when the main process (Test Runner) exits and the `server.kill()` wasn't manually called, its still executed. Otherwise its possible to have multiple `gnatsd` processes running without being attached to a parent process.
To be honest, from the node documentation I was expecting that this happens automatically if the `detached` option is not provided to child_process.spawn, but it does not seem to be working.
https://nodejs.org/api/child_process.html#child_process_options_detached

I have tested it in my local hemera setup.

PS: I also added some IDE folders to gitignore and removed the `.vscode` folder.